### PR TITLE
카카오 로그인 구현

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Jwt/SecurityConfig.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Jwt/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers("/member/sign-in", "/member/join").permitAll()
+                .requestMatchers("/member/sign-in", "/member/join",
+                        "/oauth/kakao/login", "/oauth/kakao/callback").permitAll()
                 .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
                         UsernamePasswordAuthenticationFilter.class);

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
@@ -106,15 +106,13 @@ public class MemberController {
     }
 
     @PostMapping("/join")
-    public ResponseEntity<String> saveBasicInfo(@RequestBody MemberJoinReq userInfoReq) {
-        Long userNum = memberService.save(userInfoReq);
-        if (userNum != null)
-            return ResponseEntity.status(HttpStatus.OK).body("회원 가입 완료 " + userNum);
-        return  ResponseEntity.status(HttpStatus.OK).body("회원가입 실패");
+    public ResponseEntity<Member> saveBasicInfo(@RequestBody MemberJoinReq userInfoReq) {
+        Member joinMember = memberService.save(userInfoReq);
+        return ResponseEntity.status(HttpStatus.OK).body(joinMember);
     }
 
     @PostMapping("/sign-in")
-    public ResponseEntity<TokenDto> sign_in(@RequestBody PostSignInReq postSignInReq, HttpServletResponse response) {
+    public ResponseEntity<Member> sign_in(@RequestBody PostSignInReq postSignInReq, HttpServletResponse response) {
 
         // 로그인 요청 보낸 멤버 정보
         Member loginMember = memberRepository.findMemberByEmail(postSignInReq.getEmail());
@@ -127,7 +125,7 @@ public class MemberController {
         TokenDto token = memberService.setTokenInHeader(loginMember, response);
 
         // 로그인 성공시
-        return ResponseEntity.status(HttpStatus.OK).body(token);
+        return ResponseEntity.status(HttpStatus.OK).body(loginMember);
     }
 
     @GetMapping("/test")

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MemberController {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
-    private final Logger log = LoggerFactory.getLogger(getClass());
 
 
     @Autowired
@@ -124,17 +123,8 @@ public class MemberController {
         if (loginMember == null && loginMember.getPasswd().equals(postSignInReq.getPasswd()))
             return ResponseEntity.status(HttpStatus.OK).body(null);
 
-        // 액세스 토큰 발급
-        TokenDto token = memberService.signIn(loginMember);
-        log.info("request email = {}, password = {}", loginMember.getEmail(), loginMember.getPasswd());
-        log.info("jwtToken accessToken = {}, refreshToken = {}", token.getAccessToken(), token.getRefreshToken());
-
-
-        // Header에 정보 넘겨주기
-        response.setHeader("MemberEmail", loginMember.getEmail());
-        response.setHeader("TokenType", "Bearer");
-        response.setHeader("AccessToken", token.getAccessToken());
-        response.setHeader("RefreshToken", token.getRefreshToken());
+        // 토큰 생성 및 헤더에 토큰 정보 추가
+        TokenDto token = memberService.setTokenInHeader(loginMember, response);
 
         // 로그인 성공시
         return ResponseEntity.status(HttpStatus.OK).body(token);

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
@@ -6,7 +6,10 @@ import com.togetherwithocean.TWO.Member.Authority;
 import com.togetherwithocean.TWO.Member.DTO.MemberJoinReq;
 import com.togetherwithocean.TWO.Member.Domain.Member;
 import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
 
     // 유저명으로 유저 찾기
@@ -64,9 +68,20 @@ public class MemberService {
     }
 
     @Transactional
-    public TokenDto signIn(Member loginMember) {
+    public TokenDto setTokenInHeader(Member loginMember, HttpServletResponse response) {
         // 토큰 생성
         TokenDto jwtToken = jwtProvider.generateToken(loginMember);
+
+        // 액세스 토큰 발급
+        log.info("request email = {}, password = {}", loginMember.getEmail(), loginMember.getPasswd());
+        log.info("jwtToken accessToken = {}, refreshToken = {}", jwtToken.getAccessToken(), jwtToken.getRefreshToken());
+
+        // Header에 정보 넘겨주기
+        response.setHeader("MemberEmail", loginMember.getEmail());
+        response.setHeader("TokenType", "Bearer");
+        response.setHeader("AccessToken", jwtToken.getAccessToken());
+        response.setHeader("RefreshToken", jwtToken.getRefreshToken());
+
         return jwtToken;
     }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Long save(MemberJoinReq memberSave) {
+    public Member save(MemberJoinReq memberSave) {
         System.out.println(memberSave.getPasswd() + " "+ memberSave.getCheckPasswd());
 
         // 비밀번호 일치 여부 예외처리?
@@ -59,7 +59,7 @@ public class MemberService {
                 .authority(Authority.ROLE_USER.toString())
                 .build();
         memberRepository.save(member);
-        return member.getMemberNumber();
+        return member;
     }
  
     @Transactional

--- a/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Controller/AuthController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.togetherwithocean.TWO.OAuth.Controller;
+
+
+import com.togetherwithocean.TWO.OAuth.DTO.KakaoUserInfo;
+import com.togetherwithocean.TWO.OAuth.Service.KakaoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
+public class AuthController {
+    private String redirectUri = "http://localhost:8080/oauth/kakao/callback";
+    private String clientId = "4f70d41bf691ab5b26944b067390995b";
+    private final KakaoService kakaoService;
+
+    @GetMapping("/kakao/login")
+    public ResponseEntity<String> kakaoLogin() {
+        String kakaoLoginUrl =
+                "https://kauth.kakao.com/oauth/authorize?client_id=" + clientId
+                        + "&redirect_uri=" + redirectUri + "&response_type=code";
+        return ResponseEntity.status(HttpStatus.OK).body(kakaoLoginUrl);
+    }
+
+    @GetMapping("/kakao/callback")
+    public @ResponseBody ResponseEntity<String> kakaoCallback(@RequestParam String code) {
+        String accessToken = kakaoService.getAccessToken(code);
+        KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfoByAccessToken(accessToken);
+        System.out.println(kakaoUserInfo.getName());
+        System.out.println(kakaoUserInfo.getEmail());
+        System.out.println(kakaoUserInfo.getPhoneNumber());
+        return ResponseEntity.status(HttpStatus.OK).body("유저 정보 " + kakaoUserInfo.toString());
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Controller/AuthController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     }
 
     @GetMapping("/kakao/callback")
-    public @ResponseBody ResponseEntity<String> kakaoCallback(@RequestParam String code, HttpServletResponse response) {
+    public @ResponseBody ResponseEntity<Member> kakaoCallback(@RequestParam String code, HttpServletResponse response) {
         String accessToken = kakaoService.getAccessToken(code);
         KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfoByAccessToken(accessToken);
 //        System.out.println(kakaoUserInfo.getName());
@@ -42,12 +42,12 @@ public class AuthController {
         Member loginMember = memberRepository.findMemberByEmail(kakaoUserInfo.getEmail());
 
         if (loginMember == null)
-            return ResponseEntity.status(HttpStatus.OK).body("가입하지 않은 사용자입니다.");
+            return ResponseEntity.status(HttpStatus.OK).body(null);
 
         // 토큰 생성 및 헤더에 토큰 정보 추가
         TokenDto token = memberService.setTokenInHeader(loginMember, response);
 
         // 로그인 성공시 사용자 반환
-        return ResponseEntity.status(HttpStatus.OK).body(token.toString());
+        return ResponseEntity.status(HttpStatus.OK).body(loginMember);
     }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Controller/AuthController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Controller/AuthController.java
@@ -1,8 +1,13 @@
 package com.togetherwithocean.TWO.OAuth.Controller;
 
 
+import com.togetherwithocean.TWO.Jwt.TokenDto;
+import com.togetherwithocean.TWO.Member.Domain.Member;
+import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
+import com.togetherwithocean.TWO.Member.Service.MemberService;
 import com.togetherwithocean.TWO.OAuth.DTO.KakaoUserInfo;
 import com.togetherwithocean.TWO.OAuth.Service.KakaoService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +19,8 @@ public class AuthController {
     private String redirectUri = "http://localhost:8080/oauth/kakao/callback";
     private String clientId = "4f70d41bf691ab5b26944b067390995b";
     private final KakaoService kakaoService;
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     @GetMapping("/kakao/login")
     public ResponseEntity<String> kakaoLogin() {
@@ -24,12 +31,23 @@ public class AuthController {
     }
 
     @GetMapping("/kakao/callback")
-    public @ResponseBody ResponseEntity<String> kakaoCallback(@RequestParam String code) {
+    public @ResponseBody ResponseEntity<String> kakaoCallback(@RequestParam String code, HttpServletResponse response) {
         String accessToken = kakaoService.getAccessToken(code);
         KakaoUserInfo kakaoUserInfo = kakaoService.getUserInfoByAccessToken(accessToken);
-        System.out.println(kakaoUserInfo.getName());
-        System.out.println(kakaoUserInfo.getEmail());
-        System.out.println(kakaoUserInfo.getPhoneNumber());
-        return ResponseEntity.status(HttpStatus.OK).body("유저 정보 " + kakaoUserInfo.toString());
+//        System.out.println(kakaoUserInfo.getName());
+//        System.out.println(kakaoUserInfo.getEmail());
+//        System.out.println(kakaoUserInfo.getPhoneNumber());
+
+        // 카카오에서 가져온 정보 바탕으로 사용자 찾기
+        Member loginMember = memberRepository.findMemberByEmail(kakaoUserInfo.getEmail());
+
+        if (loginMember == null)
+            return ResponseEntity.status(HttpStatus.OK).body("가입하지 않은 사용자입니다.");
+
+        // 토큰 생성 및 헤더에 토큰 정보 추가
+        TokenDto token = memberService.setTokenInHeader(loginMember, response);
+
+        // 로그인 성공시 사용자 반환
+        return ResponseEntity.status(HttpStatus.OK).body(token.toString());
     }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/DTO/KakaoAccessTokenDTO.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/DTO/KakaoAccessTokenDTO.java
@@ -1,0 +1,24 @@
+package com.togetherwithocean.TWO.OAuth.DTO;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoAccessTokenDTO {
+
+    // 토큰 타입, bearer로 고정
+    private String token_type;
+
+    // 사용자 액세스 토큰 값
+    private String access_token;
+
+    // 액세스 토큰과 ID 토큰의 만료 시간(초)
+    private Integer expires_in;
+
+    // 사용자 리프레시 토큰 값
+    private String refresh_token;
+
+    // 리프레시 토큰 만료 시간(초)
+    private Integer refresh_token_expires_in;
+
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/DTO/KakaoUserInfo.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/DTO/KakaoUserInfo.java
@@ -1,0 +1,20 @@
+package com.togetherwithocean.TWO.OAuth.DTO;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserInfo {
+    private String name;
+    private String email;
+    private String phoneNumber;
+
+    @Builder
+    public KakaoUserInfo(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Service/KakaoService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/OAuth/Service/KakaoService.java
@@ -1,0 +1,92 @@
+package com.togetherwithocean.TWO.OAuth.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.togetherwithocean.TWO.OAuth.DTO.KakaoAccessTokenDTO;
+import com.togetherwithocean.TWO.OAuth.DTO.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import javax.swing.plaf.IconUIResource;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+    private String redirectUri = "http://localhost:8080/oauth/kakao/callback";
+    private String clientId = "4f70d41bf691ab5b26944b067390995b";
+    private final ObjectMapper objectMapper;
+
+
+    @Transactional
+    public String getAccessToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // Request에 담을 정보 추가
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        // request를 하기위해 HttpEntity 객체에 헤더와 정보 조립
+        HttpEntity<LinkedMultiValueMap<String, String>> request = new HttpEntity<>(params, httpHeaders);
+
+        // code에 대한 인증요청을 할 url
+        String url = "https://kauth.kakao.com/oauth/token";
+
+        // code에 대한 인증요청을 보낸뒤 결과를 받아 response 객체에 담아 받는다.
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+        String accessToken = null;
+        try {
+            accessToken = objectMapper.readValue(response.getBody(), KakaoAccessTokenDTO.class).getAccess_token();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return accessToken;
+    }
+
+    @Transactional
+    public KakaoUserInfo getUserInfoByAccessToken(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        // Request에 담을 정보 추가
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, httpHeaders);
+
+        // 유저 정보를 받기위해 요청할 kakao 서버 url
+        String url = "https://kapi.kakao.com/v2/user/me";
+        String info = restTemplate.postForObject(url, request, String.class);
+        try {
+            JsonNode jsonNode = objectMapper.readTree(info);
+            String email = String.valueOf(jsonNode.get("kakao_account").get("email"));
+            String emailResult = email.substring(1, email.length() - 1);
+            String name = String.valueOf(jsonNode.get("kakao_account").get("name"));
+            String nameResult = name.substring(1, name.length() - 1);
+            String phoneNumber = String.valueOf(jsonNode.get("kakao_account").get("phone_number"));
+            String phoneNumberResult = "0" + phoneNumber.substring(1, phoneNumber.length() - 1).replace("+82 ", "");
+
+            KakaoUserInfo kakaoUserInfo = KakaoUserInfo.builder()
+                    .name(nameResult)
+                    .email(emailResult)
+                    .phoneNumber(phoneNumberResult)
+                    .build();
+            return kakaoUserInfo;
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
변경사항
- 카카오에서 사용자 정보 받아서 받아온 사용자 정보와 이메일을 비교하여 토큰 발급 과정 실행하여 로그인
- MemberService에 `public TokenDto setTokenInHeader(Member loginMember, HttpServletResponse response)` 함수에서
토큰 발급 및 http 헤더에 토큰 추가 로직 실행하도록 수정
- 앱 내 로그인, 카카오 로그인, 회원가입시 멤버 객체 반환하는 것으로 변경 (실패시에는 null 반환)

추가 수정 필요한 부분
- 카카오로부터 별도의 토큰을 받아오는 방법이 있는건지 우리 서비스 안에서 토큰 발급을 활용하면 되는건지 모르겠지만 일단 후자로 구현!
- 파일 구조를 뭔가 깔끔하게 정리하고 싶은데 막막해서 일단 냅뒀습니다. 리팩토링 필요할듯?!
- 일단 토큰이 반환되게 하긴 했는데 어차피 http 헤더에 붙어서 가니까 member객체를 넘겨주는걸로 수정하는게 좋을듯합니다. 에러 발생시에는 유저 객체 말고 에러 문구가 가면 좋겠는데... 그래서 response 객체를 템플릿..?으로 해서 여러가지 들어갈 수 있도록 수정하는 방안은 어떨지?!
