### PR TITLE
SCURM-66 매달 1일 멤버별 월 줍깅 수 및 스코어 0으로 초기화

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Repository/MemberRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.togetherwithocean.TWO.Member.Repository;
 import com.togetherwithocean.TWO.Member.Domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -10,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
     Member findMemberByEmail(String email);
+
+    List<Member> findAll();
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/Service/PloggingService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/Service/PloggingService.java
@@ -1,4 +1,26 @@
 package com.togetherwithocean.TWO.Plogging.Service;
 
+import com.togetherwithocean.TWO.Member.Domain.Member;
+import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
 public class PloggingService {
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void initPloggingTrashNScore() {
+        List<Member> allMember = memberRepository.findAll();
+
+        for (int i = 0; i < allMember.size(); i++) {
+            allMember.get(i).setMonthlyTrashBag(0L);
+            allMember.get(i).setMonthlyScore(0L);
+            memberRepository.save(allMember.get(i));
+        }
+    }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/TwoApplication.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/TwoApplication.java
@@ -2,8 +2,10 @@ package com.togetherwithocean.TWO;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TwoApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
Spring Boot 내 스케줄링 활용해 매달 1일 멤버별 월 줍깅 수 및 스코어 0으로 초기화

1. Main Spring Boot Application에 @EnableScheduling 추가 -> Spring Boot에서 스케줄링을 활성화하겠다는 뜻
2. Plogging Service에 initPloggingTrashNScore 함수 통해 초기화 수행
   2-1. 해당 함수에 @Scheduled(cron = "0 0 0 1 * ?") 추가해 cron 주기 설정
   2-2. 매달 1일 0시 0분 0초에 실행, ? 는 요일 지정 안하겠다는 의미. 맨 마지막 요소가 요일.