### PR TITLE
SCRUM-44, SCRUM-51 줍깅 API 구현 및 월별 캘린더 조회 API 구현

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Repository/MemberRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Repository/MemberRepository.java
@@ -11,6 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
     Member findMemberByEmail(String email);
-
+    Member findMemberByMemberNumber(Long memberNumber);
     List<Member> findAll();
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Controller/PlogCalendarController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Controller/PlogCalendarController.java
@@ -5,6 +5,7 @@ import com.togetherwithocean.TWO.PlogCalendar.DTO.GetMonthlyRes;
 import com.togetherwithocean.TWO.PlogCalendar.Service.PlogCalendarService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,8 +22,10 @@ public class PlogCalendarController {
         this.plogCalendarService = calendarService;
     }
     @GetMapping("/monthly")
-    public ResponseEntity<List<GetMonthlyRes>> getMonthlyCalendar(@RequestBody GetMonthlyReq getMonthlyReq) {
-        List<GetMonthlyRes> monthlyInfo = plogCalendarService.getMonthlyInfo(getMonthlyReq);
+    public ResponseEntity<List<GetMonthlyRes>> getMonthlyCalendar(@RequestBody GetMonthlyReq getMonthlyReq, Authentication principal) {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        List<GetMonthlyRes> monthlyInfo = plogCalendarService.getMonthlyInfo(getMonthlyReq, principal);
         if (monthlyInfo == null)
             return ResponseEntity.status(HttpStatus.OK).body(null);
         else

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Controller/PlogCalendarController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Controller/PlogCalendarController.java
@@ -1,0 +1,31 @@
+package com.togetherwithocean.TWO.PlogCalendar.Controller;
+
+import com.togetherwithocean.TWO.PlogCalendar.DTO.GetMonthlyReq;
+import com.togetherwithocean.TWO.PlogCalendar.DTO.GetMonthlyRes;
+import com.togetherwithocean.TWO.PlogCalendar.Service.PlogCalendarService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/calendar")
+public class PlogCalendarController {
+
+    private final PlogCalendarService plogCalendarService;
+    public PlogCalendarController(PlogCalendarService calendarService) {
+        this.plogCalendarService = calendarService;
+    }
+    @GetMapping("/monthly")
+    public ResponseEntity<List<GetMonthlyRes>> getMonthlyCalendar(@RequestBody GetMonthlyReq getMonthlyReq) {
+        List<GetMonthlyRes> monthlyInfo = plogCalendarService.getMonthlyInfo(getMonthlyReq);
+        if (monthlyInfo == null)
+            return ResponseEntity.status(HttpStatus.OK).body(null);
+        else
+            return ResponseEntity.status(HttpStatus.OK).body(monthlyInfo);
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/GetMonthlyReq.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/GetMonthlyReq.java
@@ -1,0 +1,15 @@
+package com.togetherwithocean.TWO.PlogCalendar.DTO;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+public class GetMonthlyReq {
+    Long memberNumber;
+    LocalDate start;
+    LocalDate end;
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/GetMonthlyReq.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/GetMonthlyReq.java
@@ -9,7 +9,6 @@ import java.util.Date;
 @Data
 @NoArgsConstructor
 public class GetMonthlyReq {
-    Long memberNumber;
     LocalDate start;
     LocalDate end;
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/GetMonthlyRes.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/GetMonthlyRes.java
@@ -1,0 +1,22 @@
+package com.togetherwithocean.TWO.PlogCalendar.DTO;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class GetMonthlyRes {
+    LocalDate date;
+    Long dailyStep;
+    Boolean plogging;
+    Boolean step;
+
+    public GetMonthlyRes(LocalDate date) {
+        this.date = date;
+        this.dailyStep = 0L;
+        this.plogging = false;
+        this.step = false;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/MonthlyDto.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/DTO/MonthlyDto.java
@@ -1,0 +1,21 @@
+package com.togetherwithocean.TWO.PlogCalendar.DTO;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+public class MonthlyDto {
+    LocalDate date;
+    Long plogging;
+    Long step;
+
+    public MonthlyDto(LocalDate date, Long plogging, Long step) {
+        this.date = date;
+        this.plogging = plogging;
+        this.step = step;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Domain/PlogCalendar.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Domain/PlogCalendar.java
@@ -1,25 +1,29 @@
-package com.togetherwithocean.TWO.Calendar.Domain;
+package com.togetherwithocean.TWO.PlogCalendar.Domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
 @Entity
 @Table(name = "calendar")
 @NoArgsConstructor
-public class Calendar {
+public class PlogCalendar {
 
     @Id
-    @Column(name = "member_number", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "calendar_number")
+    private Long calendarNumber;
+
+    @Column(name = "member_number")
     private Long memberNumber;
 
-    @Id
-    @Column(name = "date", nullable = false)
-    private Date date;
+    @Column(name = "date")
+    private LocalDate date;
 
     @Column(name = "trash_bag")
     private Long trashBag;
@@ -31,7 +35,7 @@ public class Calendar {
     private Long step;
 
     @Builder
-    public Calendar(Long memberNumber, Date date, Long trashBag, String location, Long step) {
+    public PlogCalendar(Long memberNumber, LocalDate date, Long trashBag, String location, Long step) {
         this.memberNumber = memberNumber;
         this.date = date;
         this.trashBag = trashBag;

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Repository/PlogCalendarRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Repository/PlogCalendarRepository.java
@@ -1,5 +1,6 @@
 package com.togetherwithocean.TWO.PlogCalendar.Repository;
 
+import com.togetherwithocean.TWO.Member.Domain.Member;
 import com.togetherwithocean.TWO.PlogCalendar.DTO.MonthlyDto;
 import com.togetherwithocean.TWO.PlogCalendar.Domain.PlogCalendar;
 import org.springframework.cglib.core.Local;

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Repository/PlogCalendarRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Repository/PlogCalendarRepository.java
@@ -1,0 +1,19 @@
+package com.togetherwithocean.TWO.PlogCalendar.Repository;
+
+import com.togetherwithocean.TWO.PlogCalendar.DTO.MonthlyDto;
+import com.togetherwithocean.TWO.PlogCalendar.Domain.PlogCalendar;
+import org.springframework.cglib.core.Local;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+
+public interface PlogCalendarRepository extends JpaRepository<PlogCalendar, Long> {
+    @Query("SELECT new com.togetherwithocean.TWO.PlogCalendar.DTO.MonthlyDto(c.date, c.trashBag, c.step) " +
+            "from PlogCalendar c " +
+            "WHERE c.memberNumber = :num " +
+            "AND c.date BETWEEN :monthStart AND :monthEnd")
+    List<MonthlyDto> findMonthlyDtoByDate(LocalDate monthStart, LocalDate monthEnd, Long num);
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Service/PlogCalendarService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Service/PlogCalendarService.java
@@ -1,0 +1,70 @@
+package com.togetherwithocean.TWO.PlogCalendar.Service;
+
+import com.togetherwithocean.TWO.PlogCalendar.DTO.GetMonthlyReq;
+import com.togetherwithocean.TWO.PlogCalendar.DTO.GetMonthlyRes;
+import com.togetherwithocean.TWO.PlogCalendar.DTO.MonthlyDto;
+import com.togetherwithocean.TWO.Member.Domain.Member;
+import com.togetherwithocean.TWO.PlogCalendar.Repository.PlogCalendarRepository;
+import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class PlogCalendarService {
+    private final PlogCalendarRepository plogCalendarRepository;
+    private final MemberRepository memberRepository;
+
+    public Long calculateDays(LocalDate startDate, LocalDate endDate) {
+        Long days = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+
+        return days;
+    }
+
+    public List<GetMonthlyRes> initMonthlyInfo(LocalDate startDate, Long days) {
+        List<GetMonthlyRes> monthlyList = new ArrayList<>();
+
+        for (int i = 0; i < days; i++) {
+            GetMonthlyRes monthlyRes = new GetMonthlyRes(startDate.plusDays(i));
+            monthlyList.add(monthlyRes);
+        }
+        return monthlyList;
+    }
+
+    public List<GetMonthlyRes> getMonthlyInfo(GetMonthlyReq getMonthlyReq) {
+        // 월 시작 일자, 종료 일자
+        LocalDate startDate = getMonthlyReq.getStart();
+        LocalDate endDate = getMonthlyReq.getEnd();
+        Long memberNumber = getMonthlyReq.getMemberNumber();
+        Long days = calculateDays(startDate, endDate);
+
+        // Calendar DB에서 특정 유저의 특정 월에 속하는 데이터 리스트 가져옴
+        List<MonthlyDto> monthlyDtos = plogCalendarRepository.findMonthlyDtoByDate(startDate, endDate, memberNumber);
+        System.out.println(monthlyDtos);
+        List<GetMonthlyRes> monthlyRess = initMonthlyInfo(startDate, days);
+        System.out.println(monthlyRess);
+
+        for (MonthlyDto monthlyDto : monthlyDtos) {
+            LocalDate d = monthlyDto.getDate();
+
+            // 어떤 일자의 데이터인지 idx로 받아옴
+            int idx = (int) ChronoUnit.DAYS.between(startDate, d); // 인덱스를 정확하게 계산
+
+            Long dailyStep = monthlyRess.get(idx).getDailyStep();
+            Member member = memberRepository.findMemberByMemberNumber(getMonthlyReq.getMemberNumber());
+
+            monthlyRess.get(idx).setDailyStep(dailyStep + monthlyDto.getStep());
+            if (monthlyRess.get(idx).getDailyStep() > member.getStepGoal())
+                monthlyRess.get(idx).setStep(true);
+            if (monthlyDto.getPlogging() > 0)
+                monthlyRess.get(idx).setPlogging(true);
+        }
+        return monthlyRess;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Service/PlogCalendarService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/PlogCalendar/Service/PlogCalendarService.java
@@ -7,6 +7,7 @@ import com.togetherwithocean.TWO.Member.Domain.Member;
 import com.togetherwithocean.TWO.PlogCalendar.Repository.PlogCalendarRepository;
 import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -37,11 +38,11 @@ public class PlogCalendarService {
         return monthlyList;
     }
 
-    public List<GetMonthlyRes> getMonthlyInfo(GetMonthlyReq getMonthlyReq) {
+    public List<GetMonthlyRes> getMonthlyInfo(GetMonthlyReq getMonthlyReq, Authentication principal) {
         // 월 시작 일자, 종료 일자
         LocalDate startDate = getMonthlyReq.getStart();
         LocalDate endDate = getMonthlyReq.getEnd();
-        Long memberNumber = getMonthlyReq.getMemberNumber();
+        Long memberNumber = memberRepository.findMemberByEmail(principal.getName()).getMemberNumber();
         Long days = calculateDays(startDate, endDate);
 
         // Calendar DB에서 특정 유저의 특정 월에 속하는 데이터 리스트 가져옴
@@ -57,7 +58,7 @@ public class PlogCalendarService {
             int idx = (int) ChronoUnit.DAYS.between(startDate, d); // 인덱스를 정확하게 계산
 
             Long dailyStep = monthlyRess.get(idx).getDailyStep();
-            Member member = memberRepository.findMemberByMemberNumber(getMonthlyReq.getMemberNumber());
+            Member member = memberRepository.findMemberByMemberNumber(memberNumber);
 
             monthlyRess.get(idx).setDailyStep(dailyStep + monthlyDto.getStep());
             if (monthlyRess.get(idx).getDailyStep() > member.getStepGoal())

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/Controller/PloggingController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/Controller/PloggingController.java
@@ -1,22 +1,35 @@
 package com.togetherwithocean.TWO.Plogging.Controller;
 
+import com.togetherwithocean.TWO.PlogCalendar.Domain.PlogCalendar;
+import com.togetherwithocean.TWO.Plogging.DTO.PostPlogReq;
+import com.togetherwithocean.TWO.Plogging.Service.PloggingService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/plogging")
 public class PloggingController {
+    private final PloggingService ploggingService;
+
+    public PloggingController(PloggingService ploggingService) {
+        this.ploggingService = ploggingService;
+    }
 
     // 줍깅 - 장소 입력 API
     @GetMapping("/location")
-    ResponseEntity<String> getPloggingLocation (@RequestParam String address) {
+    public ResponseEntity<String> getPloggingLocation (@RequestParam String address) {
         if (address == null)
             return ResponseEntity.status(HttpStatus.OK).body(null);
         else
             return ResponseEntity.status(HttpStatus.OK).body(address);
+    }
+
+    // 줍깅 API
+    @PostMapping("/plog")
+    public ResponseEntity<PlogCalendar> doPlogging (@RequestBody PostPlogReq postPlogReq) {
+       PlogCalendar plog =  ploggingService.savePlog(postPlogReq);
+       return ResponseEntity.status(HttpStatus.OK).body(plog);
     }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/DTO/PostPlogReq.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/DTO/PostPlogReq.java
@@ -1,0 +1,24 @@
+package com.togetherwithocean.TWO.Plogging.DTO;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class PostPlogReq {
+    Long memberNumber;
+    LocalDate plogDate;
+    Long plogStep;
+    Long plogTrash;
+    String plogLoc;
+
+    public PostPlogReq(Long memberNumber, LocalDate plogDate, Long plogStep, Long plogTrash, String plogLoc) {
+        this.memberNumber = memberNumber;
+        this.plogDate = plogDate;
+        this.plogStep = plogStep;
+        this.plogTrash = plogTrash;
+        this.plogLoc = plogLoc;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/Service/PloggingService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Plogging/Service/PloggingService.java
@@ -1,18 +1,26 @@
 package com.togetherwithocean.TWO.Plogging.Service;
 
+import com.togetherwithocean.TWO.PlogCalendar.Domain.PlogCalendar;
+import com.togetherwithocean.TWO.PlogCalendar.Repository.PlogCalendarRepository;
 import com.togetherwithocean.TWO.Member.Domain.Member;
 import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
+import com.togetherwithocean.TWO.Plogging.DTO.PostPlogReq;
 import lombok.AllArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
+import java.util.Calendar;
 import java.util.List;
 
 @Service
 @AllArgsConstructor
 public class PloggingService {
     private final MemberRepository memberRepository;
+    private final PlogCalendarRepository calendarRepository;
 
+    // 매달 1일 각 멤버 월별 줍깅 수 및 스코어 0으로 초기화
     @Scheduled(cron = "0 0 0 1 * ?")
     public void initPloggingTrashNScore() {
         List<Member> allMember = memberRepository.findAll();
@@ -22,5 +30,18 @@ public class PloggingService {
             allMember.get(i).setMonthlyScore(0L);
             memberRepository.save(allMember.get(i));
         }
+    }
+
+    @Transactional
+    public PlogCalendar savePlog(PostPlogReq postPlogReq) {
+        PlogCalendar calendar = PlogCalendar.builder()
+                .date(postPlogReq.getPlogDate())
+                .trashBag(postPlogReq.getPlogTrash())
+                .location(postPlogReq.getPlogLoc())
+                .step(postPlogReq.getPlogStep())
+                .memberNumber(postPlogReq.getMemberNumber())
+                .build();
+        calendarRepository.save(calendar);
+        return calendar;
     }
 }


### PR DESCRIPTION
1. 캘린더 DB 수정 - 기본 키 calendar_number 추가
2. Calendar 도메인 PlogCalendar 도메인으로 수정
3. PlogCalendar 중 Date 타입 -> LocalDate로 수정
4. 줍깅 API 구현
5. 월별 캘린더 조회 API 구현
-> 해당 API 돌릴 때마다 calendar 테이블 내 데이터 긁어와서 response 만드는 거라서 비효율적임
-> table 새로 파는 것 고려 필요