### PR TITLE
SCRUM-62 백엔드 전체 리빌딩

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Domain/Member.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Domain/Member.java
@@ -83,6 +83,19 @@ public class Member {
     @JsonManagedReference
     private List<Stat> statList = new ArrayList<>();
 
+    @Override
+    public String toString() {
+        return "Member{" +
+                "memberNumber=" + memberNumber +
+                ", realName='" + realName + '\'' +
+                ", nickname='" + nickname + '\'' +
+                ", email='" + email + '\'' +
+                ", charName='" + charName + '\'' +
+                ", totalPlog=" + totalPlog +
+                ", point=" + point +
+                '}';
+    }
+
     @Builder
     public Member(String realName, String nickname, String email, String passwd, String phoneNumber, String postalCode,
                 String address, String detailAddress, Long charId, String charName, Long stepGoal) {

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
@@ -100,9 +100,9 @@ public class MemberService {
         LocalDate today = LocalDate.now();
         System.out.println("today : " + today.getYear() + " " + today.getMonthValue() + " \n");
 
-        Stat stat = statRepository.findStatByMemberNumberAndDate(member.getMemberNumber(), today);
+        Stat stat = statRepository.findStatByMemberAndDate(member, today);
 
-        Long monthlyPlogging = statRepository.getMonthlyPlogging(member.getMemberNumber(), today.getYear(), today.getMonthValue());
+        Long monthlyPlogging = statRepository.getMonthlyPlogging(member, today.getYear(), today.getMonthValue());
 
         MainInfoRes mainInfo =MainInfoRes.builder()
                 .nickname(member.getNickname())

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
@@ -32,7 +32,7 @@ public class StatController {
     }
 
     // 걸음수 갱신 api
-    @GetMapping("/walk")
+    @PostMapping("/walk")
     ResponseEntity<Stat> saveStep(@RequestBody PatchStatWalkReq patchStatWalkReq, Authentication principal) {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -41,7 +41,7 @@ public class StatController {
     }
 
     // 일자별 캘린더 조회
-    @PostMapping("/daily")
+    @GetMapping("/daily")
     ResponseEntity<Stat> getPlogList(@RequestParam LocalDate date, Authentication principal) {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -51,10 +51,10 @@ public class StatController {
 
     // 월별 캘린더 및 줍깅 수, 스코어 조회
     @GetMapping("/monthly")
-    public ResponseEntity<GetMonthlyStatRes> getMonthlyStat(@RequestBody GetMonthlyCalendarReq getMonthlyCalendarReq, Authentication principal) {
+    public ResponseEntity<GetMonthlyStatRes> getMonthlyStat(@RequestParam int year, @RequestParam int month, Authentication principal) {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
-        GetMonthlyStatRes monthlyStat = statService.getMonthlyStat(getMonthlyCalendarReq, principal.getName());
+        GetMonthlyStatRes monthlyStat = statService.getMonthlyStat(year, month, principal.getName());
         if (monthlyStat == null)
             return ResponseEntity.status(HttpStatus.OK).body(null);
         else

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/DTO/GetMonthlyStatRes.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/DTO/GetMonthlyStatRes.java
@@ -4,12 +4,12 @@ import com.togetherwithocean.TWO.Stat.Domain.Stat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class GetMonthlyStatRes {
     Long monthlyPlog;
     Long monthlyScore;

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Domain/Stat.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Domain/Stat.java
@@ -22,7 +22,7 @@ public class Stat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "stat_number")
-    private Long StatNumber;
+    private Long statNumber;
 
     @Column(name = "date")
     private LocalDate date;
@@ -40,13 +40,26 @@ public class Stat {
     private Long trashBag;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_number")
+    @JoinColumn(name = "member_member_number")
     @JsonBackReference
     private Member member;
 
     @OneToMany(mappedBy = "stat")
     @JsonManagedReference
     private List<StatLoc> locationsList = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return "Stat{" +
+                "statNumber=" + statNumber +
+                ", date=" + date +
+                ", step=" + step +
+                ", achieveStep=" + achieveStep +
+                ", plogging=" + plogging +
+                ", trashBag=" + trashBag +
+                ", memberNumber=" + (member != null ? member.getMemberNumber() : null) + // member의 ID만 출력
+                '}';
+    }
 
     @Builder
     public Stat(LocalDate date, Member member) {

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Repository/StatRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Repository/StatRepository.java
@@ -1,5 +1,7 @@
 package com.togetherwithocean.TWO.Stat.Repository;
 
+import com.togetherwithocean.TWO.Member.Domain.Member;
+import com.togetherwithocean.TWO.Stat.DTO.GetMonthlyStatRes;
 import com.togetherwithocean.TWO.Stat.Domain.Stat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,13 +12,30 @@ import java.time.Month;
 import java.util.List;
 
 public interface StatRepository extends JpaRepository<Stat, Long> {
-    Stat findStatByMemberNumberAndDate(Long memberNumber, LocalDate date);
-    List<Stat> findByMemberNumberAndDateBetween(Long memberNumber, LocalDate startDate, LocalDate endDate);
+    Stat findStatByMemberAndDate(Member member, LocalDate date);
 
-    @Query(value = "SELECT SUM(s.plogging) FROM stat s WHERE s.member_number = :member_number AND YEAR(s.date) = :year AND MONTH(s.date) = :month", nativeQuery = true)
-    Long getMonthlyPlogging(
-            @Param("member_number") Long member_number,
-            @Param("year") int year,
-            @Param("month") int month
-    );
+    @Query("Select s FROM Stat s WHERE s.member = :member AND YEAR(s.date) = :year AND MONTH(s.date) = :month")
+    List<Stat> getMonthlyStat(Member member, int year, int month);
+
+
+    @Query("SELECT SUM(s.plogging)" +
+            "FROM Stat s WHERE s.member = :member AND YEAR(s.date) = :year AND MONTH(s.date) = :month")
+    Long getMonthlyPlogging(Member member, int year, int month);
+
+    // trashBag 리턴은 임의로 스코어 계산하려고 넣어둔 거임
+    // 나중에 랭킹 DB 파면 수정 필요
+    @Query("SELECT SUM(s.trashBag)" +
+            "FROM Stat s WHERE s.member = :member AND YEAR(s.date) = :year AND MONTH(s.date) = :month")
+    Long getMonthlyTrashBag(Member member, int year, int month);
+
+//    @Query(value = "SELECT SUM(s.plogging) AS monthlyPlog, " +
+//            "SUM(s.trash_bag) AS monthlyScore, " +
+//            "s.* AS monthlyCalendar" + // 모든 Stat 컬럼 선택
+//            "FROM stat s " +
+//            "WHERE s.member = :member " +
+//            "AND YEAR(s.date) = :year " +
+//            "AND MONTH(s.date) = :month " +
+//            "GROUP BY s.member_member_number", // 멤버로 그룹화
+//            nativeQuery = true)
+//    List<Object[]> getMonthlyStat(Member member, int year, int month);
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Service/StatService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Service/StatService.java
@@ -17,6 +17,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -28,8 +29,8 @@ public class StatService {
 
     public Stat savePlog(String email, PostStatSaveReq postStatSaveReq) {
         Member member = memberRepository.findMemberByEmail(email);
-        Long memberNumber = member.getMemberNumber();
-        Stat stat = statRepository.findStatByMemberNumberAndDate(memberNumber, postStatSaveReq.getDate());
+        Stat stat = statRepository.findStatByMemberAndDate(member, postStatSaveReq.getDate());
+        System.out.println(stat);
 
         // member의 상태 갱신 -> MemberService
         // 신청 가능 쓰레기 봉투 수, 일 쓰레기봉투 수, 일 줍깅 수, 총 줍깅 수 갱신
@@ -40,16 +41,15 @@ public class StatService {
 
         // 포인트 및 스코어 갱신
         // 포인트 갱신 공식 의논할 필요 있음
-        // DB에 스코어 점수가 따로 없음 -> 속성 추가할지 아니면 해당 월, 주마다 데이터 긁어와서 계산할지 !
-        member.setPoint(member.getPoint() + postStatSaveReq.getTrashBag() * 10000);
+        member.setPoint(member.getPoint() + postStatSaveReq.getTrashBag() * 100);
 
         // 추천 지역이면 추가 포인트 지급 로직 추가 필요
-        Location location = locationRepository.findLocationByName(postStatSaveReq.getLocation());
-        if (location != null)
+//        Location location = locationRepository.findLocationByName(postStatSaveReq.getLocation());
+//        if (location != null)
             // 추가 포인트
-//        member.setPoint(member.getPoint() + plogReq.getTrashBag() * 1000);
-//        member.setMonthlyScore(member.getMonthlyScore() + plogReq.getTrashBag() * 1000);
 
+        // DB에 스코어 점수가 따로 없음 -> 속성 추가할지 아니면 해당 월, 주마다 데이터 긁어와서 계산할지 !
+//      member.setMonthlyScore(member.getMonthlyScore() + plogReq.getTrashBag() * 1000);
         statRepository.save(stat);
         return stat;
     }
@@ -57,15 +57,14 @@ public class StatService {
     // 걷깅이던 줍깅이던 관계 없이 걸음 수 및 포인트 갱신
     public Stat saveStep(PatchStatWalkReq patchStatWalkReq, String email) {
         Member member = memberRepository.findMemberByEmail(email);
-        Long memberNumber = member.getMemberNumber();
-        Stat stat = statRepository.findStatByMemberNumberAndDate(memberNumber, patchStatWalkReq.getDate());
+        Stat stat = statRepository.findStatByMemberAndDate(member, patchStatWalkReq.getDate());
 
         // 사용자의 걸음 갱신
         stat.setStep(stat.getStep() + patchStatWalkReq.getStep());
 
         // 포인트, 스코어 정보 갱신
         // 포인트 갱신 공식 의논할 필요 있음
-        member.setPoint(member.getPoint() + patchStatWalkReq.getStep() * 1000);
+        member.setPoint(member.getPoint() + (long)(patchStatWalkReq.getStep() * 0.01));
         // DB에 스코어 점수가 따로 없음 -> 속성 추가할지 아니면 해당 월, 주마다 데이터 긁어와서 계산할지 !
 
         memberRepository.save(member);
@@ -74,28 +73,24 @@ public class StatService {
     }
 
     public Stat getPlogs(String email, LocalDate date) {
-        Long memberNumber = memberRepository.findMemberByEmail(email).getMemberNumber();
-        Stat stat = statRepository.findStatByMemberNumberAndDate(memberNumber, date);
+        Member member = memberRepository.findMemberByEmail(email);
+        Stat stat = statRepository.findStatByMemberAndDate(member, date);
 
         return stat;
     }
 
-    public GetMonthlyStatRes getMonthlyStat(GetMonthlyCalendarReq getMonthlyCalendarReq, String email) {
-        Long memberNumber = memberRepository.findMemberByEmail(email).getMemberNumber();
-        LocalDate startDate = getMonthlyCalendarReq.getStartDate();
-        LocalDate endDate = getMonthlyCalendarReq.getEndDate();
+    public GetMonthlyStatRes getMonthlyStat(int year, int month, String email) {
+        Member member = memberRepository.findMemberByEmail(email);
 
         // Calendar DB에서 특정 유저의 특정 월에 속하는 데이터 리스트 가져옴
-        List<Stat> month = statRepository.findByMemberNumberAndDateBetween(memberNumber, startDate, endDate);
-        Long sumPlog = 0L;
-        Long sumPoint = 0L;
+        Long monthlyPlogs =  statRepository.getMonthlyPlogging(member, year, month);
+        Long monthlyScore =  statRepository.getMonthlyTrashBag(member, year, month);
+        List<Stat> monthlyStats = statRepository.getMonthlyStat(member, year, month);
 
-        for (int i = 0; i < month.size(); i++) {
-            sumPlog += month.get(i).getPlogging();
-            sumPoint += month.get(i).getStep() * 1000 +  month.get(i).getTrashBag() * 10000;
-        }
-
-        return new GetMonthlyStatRes(sumPlog, sumPoint, month);
+        // Score 계산
+        // 추후엔 랭킹 DB 만들어서 거기서 뽑아오면 될 듯
+        // 지금은 임의로 로직 작성해두겠음
+        return new GetMonthlyStatRes(monthlyPlogs, monthlyScore * 10000, monthlyStats);
     }
 
     public void makeNewStat(Member member, LocalDate date) {

--- a/TWO/src/main/java/com/togetherwithocean/TWO/StatLoc/Domain/StatLoc.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/StatLoc/Domain/StatLoc.java
@@ -18,10 +18,10 @@ public class StatLoc {
     private Long statLocNumber;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "stat_number")
+    @JoinColumn(name = "stat_stat_number")
     private Stat stat;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "location_number")
+    @JoinColumn(name = "location_location_number")
     private Location location;
 }

--- a/TWO/src/main/resources/application.properties
+++ b/TWO/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.profiles.include=mysql, verify, jwt
 
 # hibernate
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.output.ansi.enabled=always


### PR DESCRIPTION
서버 고침 !
문제 1. 연관 관계에서 자식 클래스에서 JoinColumn으로 부모 클래스의 속성과의 매핑
-> JoinColumn 어노테이션 사용시 이름 규칙 존재
-> 부모엔티티명_참조컬럼명 (Member 테이블의 member_number 참조시)
=> @JoinColumn(name = "member_member_number")

문제 2. 순환 참조, 부모 테이블과 자식 테이블의 무한 참조
-> 부모 클래스 도메인의 해당 컬럼에 @JsonManagedReference 추가, 자식 클래스 도메인의 해당 컬럼에 @JsonBackReference 추가

문제 3. 위 내용 적용해도 Repository의 save 과정?에서 toString() 함수 사용하는 것 같은데 여기에서 무한 참조 발생
-> 부모, 자식 클래스의 도메인 모두에 toString 함수 오버라이딩 해줌
-> 참조 컬럼 제외, 주요 컬럼만 적어주면 되는 듯

---------------------------------------------------------------------------------------------

개발 수정 사항
StatRepository 쿼리문
@Query("SELECT SUM(s.trashBag)" +
            "FROM Stat s WHERE s.member = :member AND YEAR(s.date) = :year AND MONTH(s.date) = :month")
Long getMonthlyTrashBag(Member member, int year, int month);
    
@Query("Select s FROM Stat s WHERE s.member = :member AND YEAR(s.date) = :year AND MONTH(s.date) = :month")
List<Stat> getMonthlyStat(Member member, int year, int month);

- Stat에서 Member와 member_number로 매핑되어있지만 바로 접근 가능한 건 Member기 때문에 위처럼 작성함.
- year, month 정보 받아 위처럼 적용해줌

StatController 
- Get, PostMapping 수정 및 RequestBody, RequestParam 수정

---------------------------------------------------------------------------------------------

추가 고려 사항
- 걸음 수 갱신 api
-> 걸음 수 반영과 동시에 성취 여부도 갱신 필요

- 줍깅 api
-> 추천 장소던 아니던 줍깅 통계에 장소 추가 필요

- 추천 장소 DB
-> 내용 필요

- 랭킹 DB
-> 해당 테이블 생성해서 멤버 별 스코어 관리 필요