### PR TITLE
SCRUM-64 방문 장소 추가

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/DTO/MemberRes.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/DTO/MemberRes.java
@@ -1,0 +1,46 @@
+package com.togetherwithocean.TWO.Member.DTO;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class MemberRes {
+    String realName;
+    String nickname;
+    String email;
+    String passwd;
+    String phoneNumber;
+    String postalCode;
+    String address;
+    String detailAddress;
+    Long charId;
+    String charName;
+    Long stepGoal;
+    Long availTrashBag;
+    Long totalPlog;
+    Long point;
+
+    @Builder
+    MemberRes(String realName, String nickname, String email, String passwd, String phoneNumber, String postalCode,
+              String address, String detailAddress, Long charId, String charName, Long stepGoal, Long availTrashBag,
+              Long totalPlog, Long point)
+    {
+        this.realName = realName;
+        this.nickname = nickname;
+        this.email = email;
+        this.passwd = passwd;
+        this.phoneNumber = phoneNumber;
+        this.postalCode = postalCode;
+        this.address = address;
+        this.detailAddress = detailAddress;
+        this.charId = charId;
+        this.charName = charName;
+        this.stepGoal = stepGoal;
+        this.availTrashBag = availTrashBag;
+        this.totalPlog = totalPlog;
+        this.point = point;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/DTO/PostSignInRes.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/DTO/PostSignInRes.java
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class PostSignInRes {
-    Member member;
+    MemberRes memberRes;
     TokenDto token;
 
     @Builder
-    public PostSignInRes(Member member, TokenDto token) {
-        this.member = member;
+    public PostSignInRes(MemberRes memberRes, TokenDto token) {
+        this.memberRes = memberRes;
         this.token = token;
     }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Domain/Member.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Domain/Member.java
@@ -86,7 +86,7 @@ public class Member {
 //    @OneToOne
 //    @JoinColumn(name = "ranking_ranking_number", unique = true)
 //    private Ranking ranking;
-    @OneToOne(cascade = CascadeType.ALL) // CascadeType.ALL을 사용하여 Ranking 엔티티가 자동으로 저장되도록 함
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER) // CascadeType.ALL을 사용하여 Ranking 엔티티가 자동으로 저장되도록 함
     @JoinColumn(name = "ranking_ranking_number", unique = true)
     private Ranking ranking;
 
@@ -108,7 +108,7 @@ public class Member {
         this.charId = charId;
         this.charName = charName;
         this.stepGoal = stepGoal;
-        this.availTrashBag = 10L;
+        this.availTrashBag = 0L;
         this.totalPlog = 0L;
         this.point = 0L;
         this.ranking = ranking;

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Repository/MemberRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Repository/MemberRepository.java
@@ -12,5 +12,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
     Member findMemberByEmail(String email);
-    Long findRankingNumberByEmail(String email);
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
@@ -4,13 +4,11 @@ import com.togetherwithocean.TWO.Item.Service.ItemSerivce;
 import com.togetherwithocean.TWO.Jwt.JwtProvider;
 import com.togetherwithocean.TWO.Jwt.TokenDto;
 import com.togetherwithocean.TWO.Member.Authority;
-import com.togetherwithocean.TWO.Member.DTO.MainInfoRes;
-import com.togetherwithocean.TWO.Member.DTO.MemberJoinReq;
-import com.togetherwithocean.TWO.Member.DTO.PatchChangeAddress;
-import com.togetherwithocean.TWO.Member.DTO.PostSignInRes;
+import com.togetherwithocean.TWO.Member.DTO.*;
 import com.togetherwithocean.TWO.Member.Domain.Member;
 import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
 import com.togetherwithocean.TWO.Ranking.Domain.Ranking;
+import com.togetherwithocean.TWO.Ranking.Repository.RankingRepository;
 import com.togetherwithocean.TWO.Stat.Domain.Stat;
 import com.togetherwithocean.TWO.Stat.Repository.StatRepository;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,6 +26,7 @@ import java.time.LocalDate;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final StatRepository statRepository;
+    private final RankingRepository rankingRepository;
     private final ItemSerivce itemSerivce;
     private final JwtProvider jwtProvider;
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -48,7 +47,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Member save(MemberJoinReq memberSave) {
+    public MemberRes save(MemberJoinReq memberSave) {
         System.out.println(memberSave.getPasswd() + " "+ memberSave.getCheckPasswd());
 
         // 비밀번호 일치 여부 예외처리?
@@ -73,10 +72,29 @@ public class MemberService {
                 .ranking(ranking)
                 .build();
 
-        ranking.setMember(member);
-
         memberRepository.save(member);
-        return member;
+
+        ranking.setMember(member);
+        rankingRepository.save(ranking);
+
+        MemberRes memberRes = MemberRes.builder()
+                .realName(member.getRealName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .passwd(member.getPasswd())
+                .phoneNumber(member.getPhoneNumber())
+                .postalCode(member.getPostalCode())
+                .address(member.getAddress())
+                .detailAddress(member.getDetailAddress())
+                .charId(member.getCharId())
+                .charName(member.getCharName())
+                .stepGoal(member.getStepGoal())
+                .availTrashBag(member.getAvailTrashBag())
+                .totalPlog(member.getTotalPlog())
+                .point(member.getPoint())
+                .build();
+
+        return memberRes;
     }
  
     @Transactional
@@ -100,8 +118,8 @@ public class MemberService {
         return jwtToken;
     }
 
-    public PostSignInRes setSignInInfo(Member loginMember, TokenDto token) {
-        return new PostSignInRes(loginMember, token);
+    public PostSignInRes setSignInInfo(MemberRes memberRes, TokenDto token) {
+        return new PostSignInRes(memberRes, token);
     }
 
     public MainInfoRes getMainInfo(String email) {

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Repository/RecommendRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Repository/RecommendRepository.java
@@ -1,4 +1,4 @@
-package com.togetherwithocean.TWO.Stat;
+package com.togetherwithocean.TWO.Recommend.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.togetherwithocean.TWO.Recommend.Domain.Recommend;

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
@@ -1,9 +1,6 @@
 package com.togetherwithocean.TWO.Stat.Controller;
 
-import com.togetherwithocean.TWO.Stat.DTO.GetMonthlyCalendarReq;
-import com.togetherwithocean.TWO.Stat.DTO.GetMonthlyStatRes;
-import com.togetherwithocean.TWO.Stat.DTO.PatchStatWalkReq;
-import com.togetherwithocean.TWO.Stat.DTO.PostStatSaveReq;
+import com.togetherwithocean.TWO.Stat.DTO.*;
 import com.togetherwithocean.TWO.Stat.Domain.Stat;
 import com.togetherwithocean.TWO.Stat.Service.StatService;
 import lombok.AllArgsConstructor;
@@ -24,20 +21,20 @@ public class StatController {
 
     // 줍깅 api
     @PostMapping("/plog")
-    ResponseEntity<Stat> savePlog(@RequestBody PostStatSaveReq postStatSaveReq, Authentication principal) {
+    ResponseEntity<StatRes> savePlog(@RequestBody PostStatSaveReq postStatSaveReq, Authentication principal) {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        Stat plog = statService.savePlog(principal.getName(), postStatSaveReq);
-        return ResponseEntity.status(HttpStatus.OK).body(plog);
+        StatRes statRes = statService.savePlog(principal.getName(), postStatSaveReq);
+        return ResponseEntity.status(HttpStatus.OK).body(statRes);
     }
 
     // 걸음수 갱신 api
     @PostMapping("/walk")
-    ResponseEntity<Stat> saveStep(@RequestBody PatchStatWalkReq patchStatWalkReq, Authentication principal) {
+    ResponseEntity<StatRes> saveStep(@RequestBody PatchStatWalkReq patchStatWalkReq, Authentication principal) {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        Stat stat = statService.saveStep(patchStatWalkReq, principal.getName());
-        return ResponseEntity.status(HttpStatus.OK).body(stat);
+        StatRes statRes = statService.saveStep(patchStatWalkReq, principal.getName());
+        return ResponseEntity.status(HttpStatus.OK).body(statRes);
     }
 
     // 일자별 캘린더 조회

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/DTO/StatRes.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/DTO/StatRes.java
@@ -1,0 +1,36 @@
+package com.togetherwithocean.TWO.Stat.DTO;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor
+public class StatRes {
+    Long statNumber;
+    LocalDate date;
+    Boolean attend;
+    Long step;
+    Boolean achieveStep;
+    Long plogging;
+    Long trashBag;
+    List<String> visit;
+
+    @Builder
+    public StatRes(Long statNumber, LocalDate date, Boolean attend, Long step,
+                   Boolean achieveStep, Long plogging, Long trashBag, List<String> visit)
+    {
+        this.statNumber = statNumber;
+        this.date = date;
+        this.attend = attend;
+        this.step = step;
+        this.achieveStep = achieveStep;
+        this.plogging = plogging;
+        this.trashBag = trashBag;
+        this.visit = visit;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Domain/Stat.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Domain/Stat.java
@@ -32,7 +32,7 @@ public class Stat {
     private Long step;
 
     @Column(name = "achieve_step")
-    private boolean achieveStep;
+    private Boolean achieveStep;
 
     @Column(name = "plogging")
     private Long plogging;

--- a/TWO/src/main/java/com/togetherwithocean/TWO/StatLoc/Domain/StatLoc.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/StatLoc/Domain/StatLoc.java
@@ -23,4 +23,10 @@ public class StatLoc {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "visit_visit_number")
     private Visit visit;
+
+    @Builder
+    public StatLoc(Stat stat, Visit visit) {
+        this.stat = stat;
+        this.visit = visit;
+    }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/StatLoc/Repository/StatLocRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/StatLoc/Repository/StatLocRepository.java
@@ -1,0 +1,8 @@
+package com.togetherwithocean.TWO.StatLoc.Repository;
+
+import com.togetherwithocean.TWO.StatLoc.Domain.StatLoc;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatLocRepository extends JpaRepository<StatLoc, Long> {
+
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Visit/Domain/Visit.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Visit/Domain/Visit.java
@@ -6,6 +6,7 @@ import com.togetherwithocean.TWO.StatLoc.Domain.StatLoc;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,6 +27,9 @@ public class Visit {
     @Column(name = "recommend")
     private Boolean recommend;
 
+    @Column(name = "date")
+    private LocalDate date;
+
     @OneToMany(mappedBy = "visit")
     private List<StatLoc> statList = new ArrayList<>();
 
@@ -35,8 +39,9 @@ public class Visit {
     private Member member;
 
     @Builder
-    public Visit(String name, Boolean recommend, Member member) {
+    public Visit(String name, LocalDate date, Boolean recommend, Member member) {
         this.name = name;
+        this.date = date;
         this.recommend = recommend;
         this.member = member;
     }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Visit/Repository/LocationRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Visit/Repository/LocationRepository.java
@@ -1,8 +1,0 @@
-package com.togetherwithocean.TWO.Visit.Repository;
-
-import com.togetherwithocean.TWO.Visit.Domain.Visit;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface LocationRepository extends JpaRepository<Visit, Long> {
-    Visit findLocationByName(String name);
-}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Visit/Repository/VisitRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Visit/Repository/VisitRepository.java
@@ -1,0 +1,17 @@
+package com.togetherwithocean.TWO.Visit.Repository;
+
+import com.togetherwithocean.TWO.Member.Domain.Member;
+import com.togetherwithocean.TWO.Visit.Domain.Visit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface VisitRepository extends JpaRepository<Visit, Long> {
+    Visit findLocationByName(String name);
+    @Query("SELECT v.name FROM Visit v WHERE v.member = :member AND v.date = :date")
+    List<String> findVisitNamesByMemberAndDate(@Param("member") Member member, @Param("date") LocalDate date);
+}


### PR DESCRIPTION
회원가입, 로그인 api -> 랭킹값 리턴으로 인해 무한 리턴
-> 리턴값 LoginRes로 수정해 기본 멤버 정보만 리턴

줍깅 api -> statLoc 리턴으로 인해 무한 리턴
-> 리턴값 StatRes로 수정해 기본 스탯 정보만 리턴
-> 방문 장소들은 visitRepository에 따로 함수 구현해 가져와 줌

visit 도메인에 date 컬럼 추가
-> stat에 방문 장소 넣기 위해 date를 특정할 필요가 있었다

줍깅 및 걷깅시 방문 장소 추가
-> visit에 방문 장소 추가
-> stat_loc에 데이터 추가