### PR TITLE
SCRUM-111 일별 캘린더 조회 수정

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
@@ -39,10 +39,10 @@ public class StatController {
 
     // 일자별 캘린더 조회
     @GetMapping("/daily")
-    ResponseEntity<Stat> getPlogList(@RequestParam LocalDate date, Authentication principal) {
+    ResponseEntity<StatRes> getPlogList(@RequestParam LocalDate date, Authentication principal) {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        Stat dailyStat = statService.getPlogs(principal.getName(), date);
+        StatRes dailyStat = statService.getDailyPlog(principal.getName(), date);
         return ResponseEntity.status(HttpStatus.OK).body(dailyStat);
     }
 

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Service/StatService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Service/StatService.java
@@ -130,11 +130,22 @@ public class StatService {
         return statRes;
     }
 
-    public Stat getPlogs(String email, LocalDate date) {
+    public StatRes getDailyPlog(String email, LocalDate date) {
         Member member = memberRepository.findMemberByEmail(email);
         Stat stat = statRepository.findStatByMemberAndDate(member, date);
 
-        return stat;
+        StatRes statRes = StatRes.builder()
+                .statNumber(stat.getStatNumber())
+                .date(stat.getDate())
+                .attend(stat.getAttend())
+                .step(stat.getStep())
+                .achieveStep(stat.getAchieveStep())
+                .plogging(stat.getPlogging())
+                .trashBag(stat.getTrashBag())
+                .visit(visitRepository.findVisitNamesByMemberAndDate(member, date))
+                .build();
+
+        return statRes;
     }
 
     public GetMonthlyStatRes getMonthlyStat(int year, int month, String email) {


### PR DESCRIPTION
일별 캘린더 조회 api 수정
- 리턴 값이 Stat이어서 locationList 리턴시 statLoc을 불러와 무한 참조 문제 발생
-> 줍깅 api의 리턴 값을 StatRes로 리턴해 무한 참조 해결한 것처럼 리턴 값 수정