### PR TITLE
SCRUM-110 월별 캘린더 조회 수정

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Controller/StatController.java
@@ -52,9 +52,6 @@ public class StatController {
         if (principal == null)
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         GetMonthlyStatRes monthlyStat = statService.getMonthlyStat(year, month, principal.getName());
-        if (monthlyStat == null)
-            return ResponseEntity.status(HttpStatus.OK).body(null);
-        else
-            return ResponseEntity.status(HttpStatus.OK).body(monthlyStat);
+        return ResponseEntity.status(HttpStatus.OK).body(monthlyStat);
     }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/DTO/GetMonthlyStatRes.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/DTO/GetMonthlyStatRes.java
@@ -13,5 +13,5 @@ import java.util.List;
 public class GetMonthlyStatRes {
     Long monthlyPlog;
     Long monthlyScore;
-    List<Stat> monthlyCalendar;
+    List<StatRes> monthlyCalendar;
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Service/StatService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Service/StatService.java
@@ -22,6 +22,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -146,7 +147,23 @@ public class StatService {
         Long monthlyScore =  ranking.getScore();
         List<Stat> monthlyStats = statRepository.getMonthlyStat(member, year, month);
 
-        return new GetMonthlyStatRes(monthlyPlogs, monthlyScore * 10000, monthlyStats);
+        List<StatRes> monthlyStatRess= new ArrayList<>();
+
+        for (int i = 0; i < monthlyStats.size(); i++) {
+            StatRes statRes = StatRes.builder()
+                    .statNumber(monthlyStats.get(i).getStatNumber())
+                    .date(monthlyStats.get(i).getDate())
+                    .attend(monthlyStats.get(i).getAttend())
+                    .step(monthlyStats.get(i).getStep())
+                    .achieveStep(monthlyStats.get(i).getAchieveStep())
+                    .plogging(monthlyStats.get(i).getPlogging())
+                    .trashBag(monthlyStats.get(i).getTrashBag())
+                    .visit(visitRepository.findVisitNamesByMemberAndDate(member, monthlyStats.get(i).getDate()))
+                    .build();
+            monthlyStatRess.add(i, statRes);
+        }
+
+        return new GetMonthlyStatRes(monthlyPlogs, monthlyScore, monthlyStatRess);
     }
 
     public Stat makeNewStat(Member member, LocalDate date) {


### PR DESCRIPTION
월별 캘린더 조회 api 수정
- 일별 캘린더 조회와 마찬가지로 무한 참조 문제 발생
-> List<Stat>이 아닌 List<StatRes>로 리턴하면 해결
-> statRepository.getMonthlyStat(member, year, month)로 불러온 List<Stat>을 하나하나 빌더를 통해 StatRes 생성 및 List<StatRes> 생성해 리턴