### PR TITLE
SCRUM-70 멤버 회원 탈퇴 api

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
@@ -175,6 +175,21 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK).body(memberRes);
     }
 
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteMember(Authentication principal) {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        Member member = memberRepository.findMemberByEmail(principal.getName());
+        String nickname = member.getNickname();
+        memberService.deleteMember(member);
+
+        if (member != null)
+            return ResponseEntity.status(HttpStatus.OK).body(nickname + "님의 회원 탈퇴가 완료되었습니다.");
+        else
+            return ResponseEntity.status(HttpStatus.OK).body(nickname + "님의 회원 탈퇴에 실패했습니다.");
+
+    }
 //    @GetMapping("/test")
 //    public ResponseEntity<String> testToken() { return ResponseEntity.status(HttpStatus.OK).body(SecurityUtil.getCurrentEmail()); }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Domain/Member.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Domain/Member.java
@@ -71,15 +71,15 @@ public class Member {
     @Column(name = "authority")
     private Authority authority;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private List<MemberBadge> badgesList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private List<MemberItem> itemsList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private List<Stat> statList = new ArrayList<>();
 
@@ -90,7 +90,7 @@ public class Member {
     @JoinColumn(name = "ranking_ranking_number", unique = true)
     private Ranking ranking;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private List<Visit> visitList = new ArrayList<>();
 

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Service/MemberService.java
@@ -231,4 +231,8 @@ public class MemberService {
 
         return memberRes;
     }
+
+    public void deleteMember(Member member) {
+        memberRepository.deleteById(member.getMemberNumber());
+    }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Domain/Stat.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Stat/Domain/Stat.java
@@ -45,7 +45,7 @@ public class Stat {
     @JsonBackReference
     private Member member;
 
-    @OneToMany(mappedBy = "stat")
+    @OneToMany(mappedBy = "stat", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private List<StatLoc> locationsList = new ArrayList<>();
 


### PR DESCRIPTION
1. memberRepository에 존재하는 deleteById를 통해 멤버 정보를 삭제한다.
2. 이때, 외래키 제약 조건으로 인해 자식 레코드를 선행 삭제해야 부모 레코드를 삭제할 수 있다는 문제 발생.
2-1. 관련 도메인에 cascade = CascadeType.REMOVE 조건 달아주기.
2-2. 관련 있는 자식 레코드 모두 조회해 선행 삭제해주기.

-> cascade = CascadeType.REMOVE 조건을 통해 문제 해결.
-> Stat 도메인에도 StatLoc과의 제약 조건때문에 cascade = CascadeType.REMOVE 조건 달아줌.

+) cascade = CascadeType.ALL은 REMOVE를 포함하고 있어 따로 설정XX