### PR TITLE
SCRUM-71 로그아웃 api 구현

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Jwt/JwtAuthenticationFilter.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.togetherwithocean.TWO.Jwt;
 
 import java.io.IOException;
+
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -25,29 +27,34 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             String refreshToken = jwtProvider.resolveRefreshToken((HttpServletRequest) request);
             System.out.println("액세스 토큰: " + accessToken);
             System.out.println("리프레쉬 토큰: " + refreshToken);
-
-            // 2. validateToken으로 토큰 유효성 검사
-            if (accessToken != null && jwtProvider.validateAccessToken(accessToken)) {
-                // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
-                Authentication authentication = jwtProvider.getAuthentication(accessToken);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            try {
+                // 2. validateToken으로 토큰 유효성 검사
+                if (accessToken != null && jwtProvider.validateAccessToken(accessToken)) {
+                    // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
+                    Authentication authentication = jwtProvider.getAuthentication(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
-            else if (refreshToken != null && jwtProvider.refreshTokenValidation(refreshToken, jwtProvider.parseClaims(accessToken).getSubject())) {
-                System.out.println("액세스 토큰 만료");
-                String email = jwtProvider.parseClaims(accessToken).getSubject();
-                String newAccessToken = jwtProvider.createAccessToken(email);
-                String newRefreshToken = jwtProvider.createRefreshToken(email);
-                HttpServletResponse httpResponse = (HttpServletResponse) response;
-                httpResponse.setHeader("AccessToken", newAccessToken);
-                httpResponse.setHeader("RefreshToken", newRefreshToken);
-                SecurityContextHolder.getContext().setAuthentication(jwtProvider.getAuthentication(accessToken));
-                System.out.println("액세스 토큰 재발급");
-                System.out.println(newAccessToken);
-                System.out.println(newRefreshToken);
+            catch (ExpiredJwtException e) {
+                if (refreshToken != null && jwtProvider.refreshTokenValidation(refreshToken, e.getClaims().getSubject())) {
+                    String email = e.getClaims().getSubject();
+                    String newAccessToken = jwtProvider.createAccessToken(email);
+                    String newRefreshToken = jwtProvider.createRefreshToken(email);
+                    HttpServletResponse httpResponse = (HttpServletResponse) response;
+                    httpResponse.setHeader("AccessToken", newAccessToken);
+                    httpResponse.setHeader("RefreshToken", newRefreshToken);
+                    SecurityContextHolder.getContext().setAuthentication(jwtProvider.getAuthentication(newAccessToken));
+                    }
+                else {
+                    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT Token");
+                    return;
+                }
             }
-            else
-                System.out.println("유효하지 않은 토큰");
+            catch (Exception e) {
+                ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT Token");
+                return;
+            }
 
             chain.doFilter(request, response); // 다음 필터로 넘어가거나, 요청 처리 진행
-    }
+        }
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Member/Controller/MemberController.java
@@ -5,6 +5,7 @@ import com.togetherwithocean.TWO.Member.DTO.*;
 import com.togetherwithocean.TWO.Member.Repository.MemberRepository;
 import com.togetherwithocean.TWO.Ranking.Service.RankingService;
 import com.togetherwithocean.TWO.Stat.Service.StatService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import com.togetherwithocean.TWO.Jwt.TokenDto;
 import com.togetherwithocean.TWO.Member.Domain.Member;
@@ -134,6 +135,14 @@ public class MemberController {
 
         // 로그인 성공시
         return ResponseEntity.status(HttpStatus.OK).body(memberService.setSignInInfo(memberRes, token));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logoutMember(Authentication principal, HttpServletRequest request) {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        memberService.logoutMember(request, principal.getName());
+        return ResponseEntity.status(HttpStatus.OK).body("로그아웃 처리되었습니다.");
     }
 
     @GetMapping("/main-info")


### PR DESCRIPTION
로그아웃 api 구현 및 토큰 검증 로직 수정

1. /member/logout 요청
-> memberService의 logoutMember 함수에서 해당 이메일의 액세스 토큰 및 리프레쉬 토큰을 가져와 
각 토큰의 만료 시간만큼 블랙 리스트 처리를 해준다.
=> redis에 LOGOUT:이메일, LOGOUT_REFRESH:이메일로 저장!

2. 로그아웃 이후 블랙리스트 처리 검증을 위한 코드를 JwtAuthenticationFilter의 doFilter함수에 수정
-> 이유는 모르겠지만 단순히 if, else로 액세스 토큰 검증, 리프레쉬 토큰 검증을 엮어줄 때 토큰 재발급은 가능한데 블랙리스트 검증이 안됨
=> try-catch문을 활용해 try 내부에서 액세스 토큰 검증, 토큰 만료시 catch문에서 리프레쉬 토큰 검증을 해주면 정상적으로 작동함.

+) 검증 로직
1. redis에서 LOGOUT:이메일, LOGOUT_REFRESH:이메일로 검색
2. 검색된 토큰이 현재 이메일의 토큰들과 일치하면 블랙리스트 처리된 것으로 판단
3. 해당 케이스에는 권한을 주지 않는다.