### PR TITLE
일주일마다 장소 추천 로직 및 추천 장소 조회

### DIFF
--- a/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Controller/RecommendController.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Controller/RecommendController.java
@@ -1,0 +1,26 @@
+package com.togetherwithocean.TWO.Recommend.Controller;
+
+import com.togetherwithocean.TWO.Recommend.DTO.RecommendPlaceDTO;
+import com.togetherwithocean.TWO.Recommend.Service.RecommendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/recommend")
+public class RecommendController {
+    private final RecommendService recommendService;
+    @GetMapping("")
+    public ResponseEntity<RecommendPlaceDTO> getRecommendPlace(Authentication principal) {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        RecommendPlaceDTO recommendPlace = recommendService.getRecommendPlace();
+        return ResponseEntity.status(HttpStatus.OK).body(recommendPlace);
+    }
+
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/DTO/RecommendPlaceDTO.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/DTO/RecommendPlaceDTO.java
@@ -1,0 +1,24 @@
+package com.togetherwithocean.TWO.Recommend.DTO;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecommendPlaceDTO {
+    String name;
+    Double latitude;
+    Double longtitude;
+    String direction;
+
+    @Builder
+    public RecommendPlaceDTO(String name, Double latitude, Double longtitude, String direction) {
+        this.name = name;
+        this.latitude = latitude;
+        this.longtitude = longtitude;
+        this.direction = direction;
+    }
+}

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Repository/RecommendRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Repository/RecommendRepository.java
@@ -14,6 +14,6 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
 
 
     @Query("UPDATE Recommend r SET r.recs = false WHERE r.direction = :direction")
-    void updateRecsByDirection(@Param("direction") String direction);
+    void updateRecsFalseByDirection(@Param("direction") String direction);
 
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Repository/RecommendRepository.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Repository/RecommendRepository.java
@@ -2,7 +2,18 @@ package com.togetherwithocean.TWO.Recommend.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.togetherwithocean.TWO.Recommend.Domain.Recommend;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecommendRepository extends JpaRepository<Recommend, Long> {
     Recommend findRecommendByName(String name);
+    @Query("SELECT COUNT(*) FROM Recommend WHERE recs=true")
+    Long getRecommendedCount();
+    @Query("SELECT r FROM Recommend r WHERE r.direction = :direction AND r.recs = false ORDER BY r.recNumber LIMIT 1")
+    Recommend getRecommendByDir(@Param("direction") String direction);
+
+
+    @Query("UPDATE Recommend r SET r.recs = false WHERE r.direction = :direction")
+    void updateRecsByDirection(@Param("direction") String direction);
+
 }

--- a/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Service/RecommendService.java
+++ b/TWO/src/main/java/com/togetherwithocean/TWO/Recommend/Service/RecommendService.java
@@ -1,0 +1,43 @@
+package com.togetherwithocean.TWO.Recommend.Service;
+
+import com.togetherwithocean.TWO.Recommend.DTO.RecommendPlaceDTO;
+import com.togetherwithocean.TWO.Recommend.Domain.Recommend;
+import com.togetherwithocean.TWO.Recommend.Repository.RecommendRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+    private final RecommendRepository recommendRepository;
+    public RecommendPlaceDTO getRecommendPlace() {
+        Long recCount = recommendRepository.getRecommendedCount(); // 지금까지 추천한 장소의 개수
+
+        // 추천한 장소 개수를 기반으로 이번에 추천할 장소의 위치 결정
+        String direction = "";
+        if (recCount % 4 == 0)
+            direction = "동해";
+        else if (recCount % 4 == 1)
+            direction = "서해";
+        else if (recCount % 4 == 2)
+            direction = "남해";
+        else if (recCount % 4 == 3)
+            direction = "제주도";
+
+        Recommend recommendLoc = recommendRepository.getRecommendByDir(direction);
+
+//        // 해당 위치의 장소들이 이미 모두 추천된 경우 -> 추천 여부를 다시 전부 false로 변경 후 다시 선택
+//        if (recommendLoc == null) {
+//            recommendRepository.updateRecsByDirection(direction);
+//            recommendLoc = recommendRepository.getRecommendByDir(direction);
+//        }
+//        이건 주기적으로 true로 바꿔줄때 확인하고 갱신하자!
+
+        return RecommendPlaceDTO.builder()
+                .longtitude(recommendLoc.getLongitude())
+                .latitude(recommendLoc.getLatitude())
+                .direction(recommendLoc.getDirection())
+                .name(recommendLoc.getName())
+                .build();
+    }
+}


### PR DESCRIPTION
현재 추천된 장소의 개수를 count하여 4로 나누어서 동해, 서해, 남해, 제주도 중에 어떤 direction의 지역을 추천할지 결정한다.  
위치가 결정되면 db에서 recommend_number(id)가 가장 작은 순서대로 추천한다.

일->월로 넘어갈 때마다 추천 장소를 변경해야 한다.
따라서, 한 주 동안 추천이 완료된 장소를 일요일 자정이 되면 recs의 필드를 true로 수정하여 이미 추천하였음을 표기한다.
만약 어떤 direction(동,서,남,제)의 모든 지역이 전부 추천되었으면 해당 direction의 지역들을 전부 false로 변경하여 초기화 시켜준다.

근데... 이 로직은 4가지 direction의 장소가 모두 동일한 경우에만 유효하다.
만약 하나의 direction을 모두 추천해서 false로 플래그를 모두 변경하면 동해, 서해, 남해, 제주도로 추천하던 순서가 변경된다.
이 문제를 보완할 더 좋은 로직을 고민할 필요가 있을 듯 하다.

---
- 추천 장소 조회 `/recommend` 는 제대로 작동하는지는 테스트 완료!
        db에서 recs필드 값을 true로 바꿔가면서 설정한 로직대로 동해->서해->남해->제주도 순서로 추천되는 것도 확인함
- 일주일마다 제대로 갱신되는지는 테스트가 필요하다.
